### PR TITLE
Use a more Modern CMake approach

### DIFF
--- a/atmelstart/cmd/atstart/cmd/pull.go
+++ b/atmelstart/cmd/atstart/cmd/pull.go
@@ -14,7 +14,7 @@ var pullCmd = &cobra.Command{
 		if err := atmelstart.Generate(); err != nil {
 			logrus.Fatal(err)
 		}
-		if err := atmelstart.GenerateCMakeToolchain(); err != nil {
+		if err := atmelstart.GenerateCMakeFiles(); err != nil {
 			logrus.Fatal(err)
 		}
 	},

--- a/atmelstart/templates.go
+++ b/atmelstart/templates.go
@@ -209,30 +209,57 @@ func FSMustString(useLocal bool, name string) string {
 
 var _escData = map[string]*_escFile{
 
+	"/templates/CMakeLists.txt": {
+		name:    "CMakeLists.txt",
+		local:   "templates/CMakeLists.txt",
+		size:    2309,
+		modtime: 1621175210,
+		compressed: `
+H4sIAAAAAAAC/7xV32+jRhB+918xylk65wFO1b1FuUgEk4TGv4RJm3taLcuAt4ZdurukthD/e8WCXceX
+a6O2uhe0mplv55uPj4GVdIuk5IKXdUkU/l5zhenklyBah8sFfHZ/+nw54oIVdYokr6lKJ5ej0QfwTIkF
+rA1VBpSUBlKukBmp9u5Io5l48TyYkXXsRTGZhhGMG3/uPQbEf4qiYBGTWbi2iRZ8z38IYOXFD3CxomYD
+RoJLje6uvoC7ZeQH33RkMkWgGrShhjMoeKKo2o9ompLhPBlugHXsxaE/AgD4AGtZK4aQ8QI14M4oygym
+kClZwsecsU9zusUu+9G1iKZxQFGRI7g99K5Dtq1NXoybsynbT03jtu3FEYsibduRpR/2Gh514v/MwFCV
+oyEH9U+Qx+lWT7ezYboTrkOvKVf/justVQiDJ4DJsuIFKpCV4VLoA60hTobwG5Sc0mzqMumPrKq/NI3r
+r556Ss6UkKZxp/jCGbYtIX1rr6qKPZgNQooZrQsDWUFzDWZDDdQa084eCQIXtshIWbAN5cK1RrZvFiqF
+L1zWutiPPkCyB0aLgosczIZrKClTcmSfB8qk1kiGdsS2u+wYvnvObposqwXrChyNrNfpkEmpod9Ey0KK
+3OmYHULj6/G1v5yvwllAZt7i/sm7D6785+ebKycT0jEbhTTVNEOnd72+eR9QGcPfWYo7hv2UFnCqQsHF
+9u8lmIWLxyC6chybc3Il6+owbVGeF6FIX5c4ukKmvwgqpGuP54icnYt44cRv23rGxRbVmilemcHilyMU
+af/Wrc8e6AuC331skKNARQ0CFSCT35CZ3kayNiAz2MtaQTC7s8HvGQqoSKGiWvdhBEFLPKJ7Dc9MxxRS
+gyTpnGzzVu5uhbFaG1l2xiupSCfDtLEX3QcxjJu+uoXVch2T26dwNh0q/OV87i2mx127vP3ZX66+tuAs
+IeGCqj2Mr/tryF04C66Od928TpBbbx2QhTc/LXETLoZGvy6jx3Bx3+kd+PEy+noGn4bRCfDd8sND8Pwj
+pd/g7kdIz7s+/0X4De7+N+HnVrItVgYyqSChbPsHVam2a54anvCCm/2ZXp0yuENWG5oUeFgJnc5WOPju
+Hp0M+Vf4yYGhvaGFceNF94u2Lz1dN/2vvPvdnSGGfq+b//U9nZWfSPD2QJd/BgAA///di55mBQkAAA==
+`,
+	},
+
 	"/templates/toolchain.cmake": {
 		name:    "toolchain.cmake",
 		local:   "templates/toolchain.cmake",
-		size:    2537,
-		modtime: 1547353474,
+		size:    4099,
+		modtime: 1621173184,
 		compressed: `
-H4sIAAAAAAAC/5xWUXObOBB+Nr9iJ8lM7PHh3k3vpQ99IDbNcbWBAdzWTxpZLEQXkHySaJth+O83wtgl
-adrJ9Qksab/9vt1Pa1hN75HUXPC6qYnCfxuuMJ9+8JM0iEJ4vfh95jiXcH2LAhVn11BIBVjvMc8xB/2g
-DdbwhZs72RigAqJ04Wg00+XGe++TdJdm/oaE3saHAaGHS9HAEpisD7xCNY5YkmW0iYO1nwBVtSukQBfp
-nrslY7NT5Hz+fOx8/sPo+fwULff/MHl4gMbwipuHMUB08/cyindPYoeAnnis8DMKo6Hi4p6LErjWDcKX
-O14hGNTGrj3HLUt2J24k85JbPyPZLvYhzbwsWJJ1cJN4ye5bcU7lS6IoA6qh4CInByVLRevpDJSUZgz/
-LghXxJ4lsZf9RTbRyidxEt0m3gZC/4OfzB4BPz5+xq/4XlH18EL8gTNE4Xr3IviCVzidvTpKoebuhXmC
-cLnervyX5zlQdk9LfGmZvOV77/YE71yCZ2qsIDVUmR4Acq6QGakGr3jZxl+TNPOSjKyCBK7awX7bJPHD
-jKyDtN/oerQ1F/eoQDPFDwOXdRC+9xOSLpMgzuDiqn2C2L1q28UxLu3Duu7CCl/KupbibC+gIu99iAqK
-ipZ6UBptNlFI3q292xQu3NrcNfUe3Jodmrdtu1jG2wHO1vGMNQYYLuIRwfIbQ3bgRhrcomgEM1wKV2P/
-1ODWlRSly2hVaXDL1+B+pFUFrjb521I0b96AuyKkbRcr/MwZdh0hF7Nxxk+f/n/OIqeGvpjDfP7Hn+AW
-QrrmTiHNNS3Q1YYazvRxXRnDj2/4leFhQH2G97F+z5S/1+J/svejb/PQiO8Ufax+c21uZdxSyeYAblUP
-qyjy05qrD8j0W0GFXPSvw5GSjURnV+0jT9n+WoKyUQzBXjsN+NUoygzmUChZw3XJ2KsNvUe7e71wKq7N
-1ItjP1zB2I5ptE2W9uKs/dQBAGhbFxQVJcLiiP/Ownddv/kDL3fdxTkWRd51Ts8vEKxqcjzfL/7rNIcZ
-YTN+R3NIs+LqV2jWlCk5pabvFKF5TvArssbQvZ34VJVoiKA1zhxnYvuPVdH/hqt2tNstsCpmxxN7Lp49
-sediDGIn5Hm23AShl+yOTK/aU45uhPiT46eEdiBZfZcQNebQGA1YFb09Fv36Y3HTx/TgqvWS27B//sAf
-Fn9yCQn26swdjvAtTzLgHZQ8oDIc9dMccRLFfpIFfgrRNou32fHT4ZHiQcJqZBojgQ9eMvI0004EjtqG
-NMMxMrLcdxy2N+tg+UTm2F/fOPSfNNQg7Lk46bRFZI02siZM1jUV+dSZTI5/+fA0VZRm5GYbrFfOZGLH
-gxeuzj0cPkbs7LP4VD0MdbCdtm04db1zJjPHQZH/zKqz/wIAAP//haM09ukJAAA=
+H4sIAAAAAAAC/7RWXW+jShJ9968okZHWVgZbmkj7MNI+YGg7reHD2+AJ2RfUgQa3Bhov4My1Rv7vV40N
+Bpskk3tz85IIqk6dOlWnSJjRHyzIuODZLgsK9v8dL1g0/o6Iix0b7qb/noxGN+DleRpuKBcQ85RBlUOY
+i5gnu4JBtWGw1HXQiAVhnm15yorRDaj/wM/oBrAot5IiPO3ryra/Aktf+9uClWUOVY/o59EN0BJ+sjSV
+v2V8LhjERZ7Bpqq25dfZLOHVZvc0DfNs9rxlVcGTfEaLTK2VUVu8clQXh7yIWCEF2JUMKJRbFvKYh/DM
+ipLnAvK4FaOg1UbGbqhoS+fHP1ead/8Z9vludAMhFbCl5ZEeF2VF05RWEmtLq40spVv0B4NdyUUCquE5
+jqnfa9gODEz+k+1n4a6s8mwmo0ejklXjc4RH8MpEHsiGRC6YyugTn4x4PH7A9t2XyQgAoJ+CfA+m7A82
+GbG0ZOMXQiYjJiIej+vtMFjFiowLBj1uMG4aaBTpdidZwNh2PDDQAtvI6CfXdW8AxxeYvASaFoxGe0kK
++FHPkIZS4AKeOT0+yLOMighSLthniHIQeQVVsZdsopYur/5VQpqHNSFZMOYiCrZFnhQ0Gy91PdCIFeiO
+tcImIsEc2/Dp15W6BzUJQyDov2tMkFETb1obgjgqCpCxsqQJGy80TzMDRIhDQFkL+nQ0mKQyWC0Jwyms
+UkZLduHCvlLPtOA1WEbFjqbpfqrUpdvB1QIvZJlGAvi5YQXrb0vdHC+b2bFI5iWsCqTBBM1YIE2fCya6
+K2JgEnjIWsGnX0MaHIAgzZQumLwX7vrhAQxMkO455PEj0GbTKWhz1zHXHmqHiXzseu5wQjPQvknkCIbZ
+6pp+j+oTAMrl4bw+AMrlvrie5q1dUNb1PWgA5E37elnwcJr42cgvrN2C8pRFfXM0yM1yvIh+2icA2Amp
+gRy2TK777DwfGMAppIF49SKAQ0C+HB7FcQqDzV02Ut+C1jkRhHlRsLBK94Mddu6c3rrteJEbh5X11dUt
+7RsK3EfXQ1ZgaxaCJROs4OHk+vWKODpyXYdIYt33yEf62tPmJgrc9WKB/UCHKUvjN2J8/yrKI4+N5QJP
+I0vkBd7jCoFcH6wHJp4TTRqmx404jnclwuzTrwbgdIK6WQtsG4HMC+RGB5ZjINnekmgW2Og7Im8Fn5iA
+Y5uPb8ViWzfXBvqt2JWmf9OWTWxvfI3byovP5XzYt4fZExev21YGnNx6ZqW3N6+HOO/oOvgt6T5Hfl9u
+zbW6qJeFDkcTtR4ZeH+6VM2bhakt3cBA8/UywDb2QFGTO1CdBNQk+kmLGNQHmqagbllERcVDUI06WnkN
+CpRz7csKB+WkpesRbC9BUWDhEB29gEeQiTQXNeScuyMh5fXwawJdnHdSsLDt4v8hgsyWRfk6i3PGNZEL
+tPfL8YC9ewPNsb1wjnwkoS+gJm8q08k885Ir9SL2b7I7Y/Q3qcnGtoeIrZmgaG7HNnFKkxIM9rRLlO4/
+nM0df9CIXVfVYQa9THnD43wnoq9DW9692x0hfP8vOfL29tqRQy7rwF/5zPc/0Gl9sI/wWov4u267TPgY
+v7Wo73DcQM6Hea7b5Xtd90Lu3/bday65vX2/Q/4MAAD//+doJxUDEAAA
 `,
 	},
 
@@ -246,6 +273,7 @@ gxeuzj0cPkbs7LP4VD0MdbCdtm04db1zJjPHQZH/zKqz/wIAAP//haM09ukJAAA=
 var _escDirs = map[string][]os.FileInfo{
 
 	"templates": {
+		_escData["/templates/CMakeLists.txt"],
 		_escData["/templates/toolchain.cmake"],
 	},
 }

--- a/atmelstart/templates/CMakeLists.txt
+++ b/atmelstart/templates/CMakeLists.txt
@@ -1,0 +1,76 @@
+cmake_minimum_required(VERSION 3.13)
+include_guard()
+
+# Atmel Start root directory.
+set(ATMEL_START_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE PATH "Path to .atstart" FORCE)
+
+# Atmel Start code as static library
+add_library(atstart STATIC
+    # Source files extracted from 'gcc/Makefile'.
+    {{- range .SourceFiles}}
+    "${ATMEL_START_DIR}/{{.}}"
+    {{- end}}
+)
+
+# Include directories extracted from 'gcc/Makefile'.
+target_include_directories(atstart PUBLIC
+    {{- range .IncludeDirs}}
+    "${ATMEL_START_DIR}/{{.}}"
+    {{- end}}
+)
+
+# Bare minimum compiler options
+target_compile_options(atstart PUBLIC
+   -mthumb
+   -mcpu={{.CPU}}
+   -D__{{.Device}}__
+)
+
+# Apply the default flags that used to be in the toolchain.cmake file previously
+# by calling this macro
+macro(atstart_use_default_flags)
+   target_compile_options(atstart PUBLIC
+      -ffunction-sections
+      -fdata-sections
+      -mlong-calls
+      $<$<COMPILE_LANGUAGE:CXX>:-fno-threadsafe-statics>
+      $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+      $<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
+   )
+   target_link_options(atstart PUBLIC
+      LINKER:--start-group
+      -lm
+      LINKER:--end-group
+      --specs=nano.specs
+      LINKER:--gc-sections
+      "-T${ATMEL_START_DIR}/{{.LinkerScript}}"
+   )
+endmacro()
+
+# Have CMake generate an object file out of your ELF file
+# by calling this macro and passing the name of your target
+macro(atstart_create_bin target)
+   add_custom_command(
+      TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${target}> $<TARGET_FILE_BASE_NAME:${target}>.bin
+      WORKING_DIRECTORY $<TARGET_FILE_DIR:${target}>
+   )
+endmacro()
+
+# Have CMake generate a HEX file out of your ELF file
+# by calling this macro and passing the name of your target
+macro(atstart_create_hex target)
+   add_custom_command(
+      TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${target}> $<TARGET_FILE_BASE_NAME:${target}>.hex
+      WORKING_DIRECTORY $<TARGET_FILE_DIR:${target}>
+   )
+endmacro()
+
+# Macro kept for backwards compatibility
+macro(atstart_add_executable target_name)
+    atstart_use_default_flags()
+    add_executable(${target_name} ${ARGN})
+    target_link_libraries(${target_name} atstart)
+    atstart_create_bin(${target_name})
+endmacro(atstart_add_executable)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,15 +1,23 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.13)
 project(example)
 
+add_subdirectory(.atstart)
+atstart_use_default_flags()
+
+add_executable(example main.c)
+target_link_libraries(example atstart)
+
 # Set the offset for the start of the application to leave room for the bootloader.
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--section-start=.text=0x2000")
+target_link_options(example PUBLIC -Wl,--section-start=.text=0x2000)
 
-# Target built with atmel start configuration
-atstart_add_executable(example main.c)
+# Create BIN and HEX files out of the ELF file
+atstart_create_bin(example)
+atstart_create_hex(example)
 
-# Target to upload binary using bossac.
+# Target to upload BIN file using bossac.
 add_custom_target(
     upload
-    COMMAND bossac -i -d -e -w -R -v ${CMAKE_BINARY_DIR}/example.bin
-    DEPENDS ${CMAKE_BINARY_DIR}/example.bin
+    COMMAND echo bossac -i -d -e -w -R -v $<TARGET_FILE_BASE_NAME:example>.bin
+    WORKING_DIRECTORY $<TARGET_FILE_DIR:example>
+    DEPENDS example
 )

--- a/example/readme.md
+++ b/example/readme.md
@@ -2,69 +2,74 @@
 
 This example makes the built-in LED of an [Adafruit Feather M0](https://learn.adafruit.com/adafruit-feather-m0-basic-proto/overview) blink. 
 
-**Generate the Atmel Start code** 
+## Generate the Atmel Start code
 ```
 $ atstart pull
 ```
 
-**Configure with CMake** 
+## Configure with CMake
 ```
-$ mkdir build && cd build
-$ cmake -DCMAKE_TOOLCHAIN_FILE="../.atstart/toolchain.cmake" ..
--- The C compiler identification is GNU 4.8.4
--- The CXX compiler identification is GNU 4.8.4
--- Check for working C compiler: /usr/local/bin/arm-none-eabi-gcc
--- Check for working C compiler: /usr/local/bin/arm-none-eabi-gcc -- works
+$ cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=".atstart/toolchain.cmake"
+-- Using GCC ARM from: /path/to/gcc-arm-installation
+-- The C compiler identification is GNU 10.2.1
+-- The CXX compiler identification is GNU 10.2.1
 -- Detecting C compiler ABI info
 -- Detecting C compiler ABI info - done
+-- Check for working C compiler: /path/to/gcc-arm-installation/bin/arm-none-eabi-gcc - skipped
 -- Detecting C compile features
 -- Detecting C compile features - done
--- Check for working CXX compiler: /usr/local/bin/arm-none-eabi-g++
--- Check for working CXX compiler: /usr/local/bin/arm-none-eabi-g++ -- works
 -- Detecting CXX compiler ABI info
 -- Detecting CXX compiler ABI info - done
+-- Check for working CXX compiler: /path/to/gcc-arm-installation/bin/arm-none-eabi-g++ - skipped
 -- Detecting CXX compile features
 -- Detecting CXX compile features - done
 -- Configuring done
 -- Generating done
--- Build files have been written to: github.com/jmichiels/AtmelStart/example/build
+-- Build files have been written to: github.com/jmichiels/atmel-start/example/build
 ```
-**Build with Make** 
+
+## Build
+Tell CMake to run the make command and build the `example` target. You can leave out `-- example` to build the `all` target.
 ```
-$ make example.bin
-Scanning dependencies of target example.elf
-[  4%] Building C object CMakeFiles/example.elf.dir/main.c.obj
-[  8%] Building C object CMakeFiles/example.elf.dir/.atstart/atmel_start.c.obj
-[ 13%] Building C object CMakeFiles/example.elf.dir/.atstart/driver_init.c.obj
-[ 17%] Building C object CMakeFiles/example.elf.dir/.atstart/examples/driver_examples.c.obj
-[ 21%] Building C object CMakeFiles/example.elf.dir/.atstart/hal/src/hal_atomic.c.obj
-[ 26%] Building C object CMakeFiles/example.elf.dir/.atstart/hal/src/hal_delay.c.obj
-[ 30%] Building C object CMakeFiles/example.elf.dir/.atstart/hal/src/hal_gpio.c.obj
-[ 34%] Building C object CMakeFiles/example.elf.dir/.atstart/hal/src/hal_init.c.obj
-[ 39%] Building C object CMakeFiles/example.elf.dir/.atstart/hal/src/hal_io.c.obj
-[ 43%] Building C object CMakeFiles/example.elf.dir/.atstart/hal/src/hal_sleep.c.obj
-[ 47%] Building C object CMakeFiles/example.elf.dir/.atstart/hal/utils/src/utils_assert.c.obj
-[ 52%] Building C object CMakeFiles/example.elf.dir/.atstart/hal/utils/src/utils_event.c.obj
-[ 56%] Building C object CMakeFiles/example.elf.dir/.atstart/hal/utils/src/utils_list.c.obj
-[ 60%] Building C object CMakeFiles/example.elf.dir/.atstart/hal/utils/src/utils_syscalls.c.obj
-[ 65%] Building C object CMakeFiles/example.elf.dir/.atstart/hpl/core/hpl_core_m0plus_base.c.obj
-[ 69%] Building C object CMakeFiles/example.elf.dir/.atstart/hpl/core/hpl_init.c.obj
-[ 73%] Building C object CMakeFiles/example.elf.dir/.atstart/hpl/dmac/hpl_dmac.c.obj
-[ 78%] Building C object CMakeFiles/example.elf.dir/.atstart/hpl/gclk/hpl_gclk.c.obj
-[ 82%] Building C object CMakeFiles/example.elf.dir/.atstart/hpl/pm/hpl_pm.c.obj
-[ 86%] Building C object CMakeFiles/example.elf.dir/.atstart/hpl/sysctrl/hpl_sysctrl.c.obj
-[ 91%] Building C object CMakeFiles/example.elf.dir/.atstart/samd21a/gcc/gcc/startup_samd21.c.obj
-[ 95%] Building C object CMakeFiles/example.elf.dir/.atstart/samd21a/gcc/system_samd21.c.obj
+$ cmake --build build -- example
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /Users/arnom/Projects/GitHub/github.com/jmichiels/atmel-start/example/build
+[  4%] Building C object .atstart/CMakeFiles/atstart.dir/atmel_start.c.obj
+[  8%] Building C object .atstart/CMakeFiles/atstart.dir/driver_init.c.obj
+[ 12%] Building C object .atstart/CMakeFiles/atstart.dir/examples/driver_examples.c.obj
+[ 16%] Building C object .atstart/CMakeFiles/atstart.dir/hal/src/hal_atomic.c.obj
+[ 20%] Building C object .atstart/CMakeFiles/atstart.dir/hal/src/hal_delay.c.obj
+[ 25%] Building C object .atstart/CMakeFiles/atstart.dir/hal/src/hal_gpio.c.obj
+[ 29%] Building C object .atstart/CMakeFiles/atstart.dir/hal/src/hal_init.c.obj
+[ 33%] Building C object .atstart/CMakeFiles/atstart.dir/hal/src/hal_io.c.obj
+[ 37%] Building C object .atstart/CMakeFiles/atstart.dir/hal/src/hal_sleep.c.obj
+[ 41%] Building C object .atstart/CMakeFiles/atstart.dir/hal/utils/src/utils_assert.c.obj
+[ 45%] Building C object .atstart/CMakeFiles/atstart.dir/hal/utils/src/utils_event.c.obj
+[ 50%] Building C object .atstart/CMakeFiles/atstart.dir/hal/utils/src/utils_list.c.obj
+[ 54%] Building C object .atstart/CMakeFiles/atstart.dir/hal/utils/src/utils_syscalls.c.obj
+[ 58%] Building C object .atstart/CMakeFiles/atstart.dir/hpl/core/hpl_core_m0plus_base.c.obj
+[ 62%] Building C object .atstart/CMakeFiles/atstart.dir/hpl/core/hpl_init.c.obj
+[ 66%] Building C object .atstart/CMakeFiles/atstart.dir/hpl/dmac/hpl_dmac.c.obj
+[ 70%] Building C object .atstart/CMakeFiles/atstart.dir/hpl/gclk/hpl_gclk.c.obj
+[ 75%] Building C object .atstart/CMakeFiles/atstart.dir/hpl/pm/hpl_pm.c.obj
+[ 79%] Building C object .atstart/CMakeFiles/atstart.dir/hpl/sysctrl/hpl_sysctrl.c.obj
+[ 83%] Building C object .atstart/CMakeFiles/atstart.dir/samd21a/gcc/gcc/startup_samd21.c.obj
+[ 87%] Building C object .atstart/CMakeFiles/atstart.dir/samd21a/gcc/system_samd21.c.obj
+[ 91%] Linking C static library libatstart.a
+[ 91%] Built target atstart
+[ 95%] Building C object CMakeFiles/example.dir/main.c.obj
 [100%] Linking C executable example.elf
-[100%] Built target example.elf
-Scanning dependencies of target example.bin
-[100%] Built target example.bin
+[100%] Built target example
 ```
-**Upload with [bossac](https://github.com/shumatech/BOSSA)** 
+
+## Upload with [bossac](https://github.com/shumatech/BOSSA)
 ```
-$ make upload
-[100%] Built target example.elf
-[100%] Built target example.bin
+$ cmake --build build -- upload
+Consolidate compiler generated dependencies of target atstart
+[ 91%] Built target atstart
+Consolidate compiler generated dependencies of target example
+[100%] Built target example
 Trying to connect on ttyACM0
 Set binary mode
 readWord(addr=0)=0x20007ffc

--- a/readme.md
+++ b/readme.md
@@ -1,39 +1,62 @@
 
 # Atmel START
 
-This projects consists in a command-line tool to streamline work with the [Atmel Start](http://start.atmel.com/) code generator, as well as a CMake toolchain generator which allows to integrate code generated using Atmel Start in a CMake project (for use in the [JetBrains CLion](https://www.jetbrains.com/clion/) IDE for example)
+This projects consists in a command-line tool to streamline work with the [Atmel Start](http://start.atmel.com/) code generator, as well as a CMake generator which allows to integrate code generated using Atmel Start in a CMake project.
+CMake projects can easily be used in [JetBrains CLion](https://www.jetbrains.com/clion/), [Visual Studio Code](https://code.visualstudio.com/) (using [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)) and other well-known IDEs.
 
 ## Quick Start
 
 **Install the command line tool**
-```
+```sh
 $ go get -u github.com/jmichiels/AtmelStart/atmelstart/...
 ```
+
 **Initialize the Atmel Start configuration**
-```
+```sh
 $ atstart init
 ```
 This will open a Chrome window and create a new configuration file `atstart.yaml` in the current directory. This file is the same as the one you would get using *Save Configuration* in Atmel Start. This file will automatically be kept in sync with the changes you make to the configuration as long as the Chrome window stays open.
 
 **Generate the Atmel Start code and download it**
-```
+```sh
 $ atstart pull
 ``` 
-This will generate the code, download it and extract in a `.atstart` directory. The code is the same as the one you would get using *Export Project* in Atmel Start. This will also generate ` toolchain.cmake` which you can then use to build your project.
+This will generate the code, download it and extract in a `.atstart` directory. The code is the same as the one you would get using *Export Project* in Atmel Start. This will also generate ` CMakeLists.txt` that defines a static library called `atstart` and include `toolchain.cmake` for the GCC ARM compiler.
 
 **Create your project files**
-
 Create a main code file for your project. You can copy `.atstart/main.c` down to your project directory as a starter if you wish.
 
-Create a `CMakeLists.txt` file that describes your project. Specify your executable and main file using the `atstart_add_executable` macro in that file. See `CMakeLists.txt` in the [example](example).
+Create a `CMakeLists.txt` file to defines your project, similar to the following example:
+
+```cmake
+cmake_minimum_required(VERSION 3.13)
+
+project(example)
+
+# Add the Atmel Start code
+add_subdirectory(.atstart)
+
+# Use recommended default compiler flags
+atstart_use_default_flags()
+
+# Define your executable
+add_executable(myprogram
+   src/main.c)
+
+# Link your executable with the Atmel Start code
+target_link_libraries(myprogram atstart)
+
+# Configure CMake to create a BIN file out of the ELF
+atstart_create_bin(myprogram)
+```
+
+Be sure to have a look at the [example](example) as well.
 
 **Build your project**
 
-```
-$ mkdir build
-$ cd build
-$ cmake -DCMAKE_TOOLCHAIN_FILE="../.atstart/toolchain.cmake" ..
-$ make
+```sh
+$ cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=".atstart/toolchain.cmake" -DCMAKE_BUILD_TYPE=Debug
+$ cmake --build build
 ```
 
 **Edit the Atmel Start configuration**


### PR DESCRIPTION
First of all, thanks for this project. It's my first time starting an ATSAMD project from scratch. (I typically use NXP MCUs and to be honest, their SDK/tooling is a lot more "developer friendly" than what Microchip seems to be offering. However this did help to simplify some things.)

One thing I did notice, is that the CMake files generated are rather "old school" CMake, rather than Modern CMake (see [this gist](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1) and [this online "course"](https://cliutils.gitlab.io/modern-cmake/) for a bit of background).

I've split off the Atmel Start specific instructions from `toolchain.cmake` into a separate CMakeLists.txt and defined the Atmel Start code as a separate static library with all the include paths and compile/link options set as PUBLIC options.
Rather than setting global options/variables, everything Atmel specific should be more or less linked to the `atstart` target defined in the generated `CMakeLists.txt`

I've never developer with Go before, so I still need to figure out how I can install my changes on my system in order to test them. That's why I marked the PR as a Draft.